### PR TITLE
feat: SITES-29416 [Xwalk] Add support for importing non-image assets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 import { createJcrPackage } from './package/packaging.js';
-import { getImageUrlsFromMarkdown } from './package/image-mapping.js';
+import { getAssetUrlsFromMarkdown } from './package/asset-mapping.js';
 
 export {
   createJcrPackage,
-  getImageUrlsFromMarkdown,
+  getAssetUrlsFromMarkdown,
 };

--- a/src/package/asset-mapping.js
+++ b/src/package/asset-mapping.js
@@ -18,6 +18,9 @@ const imageRegex = /!\[([^\]]*)]\(([^) "]+)(?: *"([^"]*)")?\)|!\[([^\]]*)]\[([^\
 // Regex for reference definitions
 const referenceRegex = /\[([^\]]+)]:\s*(\S+)/g;
 
+// Regex for non-image asset links (PDFs, videos, docs, etc.)
+const nonImageAssetRegex = /(?:\[(.*?)\]|\[.*?\])\(([^)]+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|rtf|txt|csv|mp4|mov|avi|wmv|mkv|flv|webm))\)|\[(.*?)\]:\s*(\S+\.(?:pdf|doc|docx|xls|xlsx|ppt|pptx|odt|ods|odp|rtf|txt|csv|mp4|mov|avi|wmv|mkv|flv|webm))/gi;
+
 /**
  * Function to find reference definitions in a markdown file.
  *
@@ -36,21 +39,21 @@ const findReferenceDefinitionsInMarkdown = (markdownContent) => {
 };
 
 /**
- * Function to scan for images in a markdown file.
+ * Function to scan for assets in a markdown file.
  *
  * @param markdownContent - The content of the markdown file
- * @returns {Array<string>} A Map of image urls as key
+ * @returns {Array<string>} A Map of asset urls as key
  */
-const findImagesInMarkdown = (markdownContent) => {
+const findAssetsInMarkdown = (markdownContent) => {
   const references = findReferenceDefinitionsInMarkdown(markdownContent);
 
-  const imageUrls = [];
+  const assetUrls = [];
 
   // Identify each image url in the markdown content
   let match;
+  let url;
   // eslint-disable-next-line no-cond-assign
   while ((match = imageRegex.exec(markdownContent)) !== null) {
-    let url;
     if (match[2]) { // Inline image
       // eslint-disable-next-line prefer-destructuring
       url = match[2];
@@ -58,40 +61,49 @@ const findImagesInMarkdown = (markdownContent) => {
       url = references[match[5]] || null; // Resolve URL from reference map
     }
     if (url) {
-      imageUrls.push(url);
+      assetUrls.push(url);
     }
   }
 
-  return imageUrls;
+  // Find and add only non-image asset links
+  // eslint-disable-next-line no-cond-assign
+  while ((match = nonImageAssetRegex.exec(markdownContent)) !== null) {
+    url = match[2] || match[3];
+    if (url) {
+      assetUrls.push(url);
+    }
+  }
+
+  return assetUrls;
 };
 
 /**
- * Get the list image urls present in the markdown.
+ * Get the list asset urls present in the markdown.
  * @param {string} markdownContent - The content of the markdown file
- * @returns {Array<string>} An array of image urls.
+ * @returns {Array<string>} An array of asset urls.
  */
-const getImageUrlsFromMarkdown = (markdownContent) => {
+const getAssetUrlsFromMarkdown = (markdownContent) => {
   try {
-    return findImagesInMarkdown(markdownContent);
+    return findAssetsInMarkdown(markdownContent);
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.warn('Error getting image urls from markdown:', error);
+    console.warn('Error getting asset urls from markdown:', error);
     return [];
   }
 };
 
 /**
- * Function to sanitize the image mappings.
+ * Function to sanitize the asset url mappings.
  * Delete all entries with empty values (meaning that they have not been used in any jcr page).
- * @param {Map} imageMap - The image mapping
- * @returns {Map} The sanitized image mapping
+ * @param {Map} assetMap - The asset url mapping
+ * @returns {Map} The sanitized asset url mapping
  */
-const sanitizeImageMappings = (imageMap) => (
-  new Map([...imageMap].filter((entry) => entry[1] != null && entry[1] !== ''))
+const sanitizeAssetMappings = (assetMap) => (
+  new Map([...assetMap].filter((entry) => entry[1] != null && entry[1] !== ''))
 );
 
 export {
   // eslint-disable-next-line import/prefer-default-export
-  getImageUrlsFromMarkdown,
-  sanitizeImageMappings,
+  getAssetUrlsFromMarkdown,
+  sanitizeAssetMappings,
 };

--- a/test/package/image-mapping.test.js
+++ b/test/package/image-mapping.test.js
@@ -11,7 +11,7 @@
  */
 /* eslint-env mocha */
 import { expect } from 'chai';
-import { getImageUrlsFromMarkdown, sanitizeImageMappings } from '../../src/package/image-mapping.js';
+import { getAssetUrlsFromMarkdown, sanitizeAssetMappings } from '../../src/package/asset-mapping.js';
 
 describe('getImageUrlsFromMarkdown', () => {
   it('should return an array of image urls (reference urls)', () => {
@@ -25,7 +25,7 @@ describe('getImageUrlsFromMarkdown', () => {
 [image0]: https://aem.live/car.jpeg
 [image1]: https://aem.live/car2.jpeg`;
 
-    const imageUrls = getImageUrlsFromMarkdown(markdownContent);
+    const imageUrls = getAssetUrlsFromMarkdown(markdownContent);
     expect(imageUrls).to.have.lengthOf(2);
     expect(imageUrls[0]).to.equal('https://aem.live/car.jpeg');
     expect(imageUrls[1]).to.equal('https://aem.live/car2.jpeg');
@@ -39,16 +39,25 @@ describe('getImageUrlsFromMarkdown', () => {
 | ![Car 2](https://aem.live/car2.jpeg)     |
 +------------------------------------------+`;
 
-    const imageUrls = getImageUrlsFromMarkdown(markdownContent);
+    const imageUrls = getAssetUrlsFromMarkdown(markdownContent);
     expect(imageUrls).to.have.lengthOf(2);
     expect(imageUrls[0]).to.equal('https://aem.live/car.jpeg');
     expect(imageUrls[1]).to.equal('https://aem.live/car2.jpeg');
   });
 
+  it('should return an non-image asset (pdf) url', () => {
+    const markdownContent = `Click [here](/content/dam/doe/foo/bar.pdf) to download the handy guide.
+    Also check [here](https://example.live/siteFoo.html).`;
+
+    const imageUrls = getAssetUrlsFromMarkdown(markdownContent);
+    expect(imageUrls).to.have.lengthOf(1);
+    expect(imageUrls[0]).to.equal('/content/dam/doe/foo/bar.pdf');
+  });
+
   it('should return an array with no image urls', () => {
     const markdownContent = 'This is a markdown file with no images.';
 
-    const imageUrls = getImageUrlsFromMarkdown(markdownContent);
+    const imageUrls = getAssetUrlsFromMarkdown(markdownContent);
     expect(imageUrls).to.have.lengthOf(0);
   });
 
@@ -62,7 +71,7 @@ describe('getImageUrlsFromMarkdown', () => {
 
 [image0]: /test/car2.jpeg`;
 
-    const imageUrls = getImageUrlsFromMarkdown(markdownContent);
+    const imageUrls = getAssetUrlsFromMarkdown(markdownContent);
     expect(imageUrls).to.have.lengthOf(2);
     expect(imageUrls[0]).to.equal('/car.jpeg');
     expect(imageUrls[1]).to.equal('/test/car2.jpeg');
@@ -77,7 +86,7 @@ describe('getImageUrlsFromMarkdown', () => {
       ['key5', 'value5'],
     ]);
 
-    const result = sanitizeImageMappings(imageMap);
+    const result = sanitizeAssetMappings(imageMap);
 
     expect(result.size).to.equal(2);
     expect(result.has('key1')).to.equal(true);
@@ -94,7 +103,7 @@ describe('getImageUrlsFromMarkdown', () => {
       ['key3', undefined],
     ]);
 
-    const result = sanitizeImageMappings(imageMap);
+    const result = sanitizeAssetMappings(imageMap);
 
     expect(result.size).to.equal(0);
   });


### PR DESCRIPTION
[SITES-29416](https://jira.corp.adobe.com/browse/SITES-29416)

We should be able to import other type of assets - pdf, video, docs -  that are linked in the page.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
