### PR TITLE
fix(sites-29443): Handle invalid JCR characters

### DIFF
--- a/src/package/packaging.js
+++ b/src/package/packaging.js
@@ -24,7 +24,7 @@ import {
 import { saveFile } from '../shared/filesystem.js';
 
 let jcrPages = [];
-const ASSET_MAPPING_FILE = 'asset-mappings.json';
+const ASSET_MAPPING_FILE = 'asset-mapping.json';
 
 const init = () => {
   jcrPages = [];

--- a/test/package/packaging-utils.test.js
+++ b/test/package/packaging-utils.test.js
@@ -98,7 +98,7 @@ describe('packaging-utils', () => {
     expect(jcrPath2).to.equal('/content/adobe/products/lightroom');
 
     // if the path starts with /content then the jcr path should be the same
-    const jcrPath3 = getJcrPagePath('/content/foo/bar/xyz', 'foo-bar');
+    const jcrPath3 = getJcrPagePath('/content/foo/bar/xyz', 'foo');
     expect(jcrPath3).to.equal('/content/foo/bar/xyz');
   });
 

--- a/test/package/packaging-utils.test.js
+++ b/test/package/packaging-utils.test.js
@@ -14,7 +14,7 @@ import { expect } from 'chai';
 import he from 'he';
 import {
   getFilterXml, getJcrPagePath, getPackageName, getParsedXml, getJcrAssetPath,
-  getPropertiesXml, traverseAndUpdateAssetReferences, getInvalidCharAdjustedPath,
+  getPropertiesXml, traverseAndUpdateAssetReferences, getSanitizedJcrPath,
 } from '../../src/package/packaging.utils.js';
 
 describe('packaging-utils', () => {
@@ -93,9 +93,13 @@ describe('packaging-utils', () => {
     const jcrPath = getJcrPagePath('/products/lightroom', 'adobe');
     expect(jcrPath).to.equal('/content/adobe/products/lightroom');
 
-    // if the path starts with /content/adobe then the jcr path should be the same
+    // if the path starts with /content then the jcr path should be the same
     const jcrPath2 = getJcrPagePath('/content/adobe/products/lightroom', 'adobe');
     expect(jcrPath2).to.equal('/content/adobe/products/lightroom');
+
+    // if the path starts with /content then the jcr path should be the same
+    const jcrPath3 = getJcrPagePath('/content/foo/bar/xyz', 'foo-bar');
+    expect(jcrPath3).to.equal('/content/foo/bar/xyz');
   });
 
   // write unit test for traverseAndUpdateAssetReferences
@@ -153,41 +157,41 @@ describe('packaging-utils', () => {
     );
   });
 
-  it('test for getInvalidCharAdjustedAssetPath', () => {
+  it('test for getSanitizedJcrPath', () => {
     // should replace invalid folder name characters
     let input = '/content/dam/inva*lid/fol:der/image.jpg';
     let expected = '/content/dam/inva-lid/fol-der/image.jpg';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(expected);
+    expect(getSanitizedJcrPath(input)).to.equal(expected);
 
     // should replace invalid file name characters
     input = '/content/dam/folder/image?.jpg';
     expected = '/content/dam/folder/image-.jpg';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(expected);
+    expect(getSanitizedJcrPath(input)).to.equal(expected);
 
     // should not modify valid paths
     input = '/content/dam/valid-folder/valid-image.jpg';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(input);
+    expect(getSanitizedJcrPath(input)).to.equal(input);
 
     // 'should handle spaces and tabs in folder names
     input = '/content/dam/folder name/another\tfolder/image.jpg';
     expected = '/content/dam/folder-name/another-folder/image.jpg';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(expected);
+    expect(getSanitizedJcrPath(input)).to.equal(expected);
 
     // should correctly handle multiple invalid characters
     input = '/content/dam/inv*ali[d]/fol^der+/ima?ge.jpg';
     expected = '/content/dam/inv-ali-d-/fol-der-/ima-ge.jpg';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(expected);
+    expect(getSanitizedJcrPath(input)).to.equal(expected);
 
     // should replace invalid characters at the start or end of a folder name
     input = '/content/dam/*invalid*/folder/';
     expected = '/content/dam/-invalid-/folder/';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(expected);
+    expect(getSanitizedJcrPath(input)).to.equal(expected);
 
     // should handle empty input gracefully
-    expect(getInvalidCharAdjustedPath('')).to.equal('');
+    expect(getSanitizedJcrPath('')).to.equal('');
 
     // should not break if given a path without a file
     input = '/content/dam/folder/';
-    expect(getInvalidCharAdjustedPath(input)).to.equal(input);
+    expect(getSanitizedJcrPath(input)).to.equal(input);
   });
 });


### PR DESCRIPTION
[SITES-29443](https://jira.corp.adobe.com/browse/SITES-29443) : Replace invalid characters in site and asset paths.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
