### PR TITLE
fix(sites-30081): [Xwalk] Update product page reference paths

### DIFF
--- a/test/package/packaging-utils.test.js
+++ b/test/package/packaging-utils.test.js
@@ -14,7 +14,7 @@ import { expect } from 'chai';
 import he from 'he';
 import {
   getFilterXml, getJcrPagePath, getPackageName, getParsedXml, getJcrAssetPath,
-  getPropertiesXml, traverseAndUpdateAssetReferences, getSanitizedJcrPath,
+  getPropertiesXml, traverseAndUpdateReferences, getSanitizedJcrPath,
 } from '../../src/package/packaging.utils.js';
 
 describe('packaging-utils', () => {
@@ -109,7 +109,7 @@ describe('packaging-utils', () => {
   <jcr:content>
     <root>
       <section>
-        <block hero_image="https://domain.com/media_a.jpeg"></block>
+        <block hero_image="https://domain.com/media_a.jpeg" link="/media/foo"></block>
         <text_1 text="&lt;p&gt;&lt;img src=&quot;/car.jpeg?width=750&amp;#x26;format=jpeg&amp;#x26;optimize=medium&quot;&gt;&lt;/p&gt;&lt;p&gt;&lt;img src=&quot;/boat.jpeg?width=750&amp;#x26;format=jpeg&amp;#x26;optimize=medium&quot;&gt;&lt;/p&gt;"/>
         <block_1>
           <item_0 image="./c.png"></item_0>
@@ -133,9 +133,10 @@ describe('packaging-utils', () => {
       ['/content/dam/folder/e.png', '/content/dam/xwalk/folder/e.png'],
     ]);
 
-    traverseAndUpdateAssetReferences(
+    traverseAndUpdateReferences(
       document.documentElement,
       pageUrl,
+      assetFolderName,
       assetFolderName,
       jcrAssetMap,
     );
@@ -147,6 +148,7 @@ describe('packaging-utils', () => {
 
     // for each block test to see if the attribute has been updated
     expect(blocks[0].getAttribute('hero_image')).to.equal('/content/dam/xwalk/media1_a.jpeg');
+    expect(blocks[0].getAttribute('link')).to.equal('/content/xwalk/media/foo');
     expect(blocks1[0].getElementsByTagName('item_0')[0].getAttribute('image')).to.equal('/content/dam/xwalk/folderxyz/c.png');
     expect(blocks1[0].getElementsByTagName('item_1')[0].getAttribute('image')).to.equal('/content/dam/xwalk/folderxyz/folder/d.png');
     expect(image[0].getAttribute('fileReference')).to.equal('/content/dam/xwalk/folder/e.png');

--- a/test/package/packaging.test.js
+++ b/test/package/packaging.test.js
@@ -12,7 +12,7 @@
 /* eslint-env mocha */
 import { readFile, rm } from 'fs/promises';
 import { expect } from 'chai';
-import { createJcrPackage, updateAssetReferences } from '../../src/package/packaging.js';
+import { createJcrPackage, updateReferences } from '../../src/package/packaging.js';
 import { getFullAssetUrl, getParsedXml } from '../../src/package/packaging.utils.js';
 
 const PAGE_URL = 'https://main--stini--bhellema.hlx.page';
@@ -57,9 +57,10 @@ describe('packaging', () => {
     // Init image URL map (original urls only, jcr paths will be added by updateAssetReferences)
     const imageUrls = await getImageUrlKeysArray();
     const actualImageUrlMapping = new Map(imageUrls.map((url) => [url, '']));
-    const actualProcessedXml = await updateAssetReferences(
+    const actualProcessedXml = await updateReferences(
       originalXml,
       PAGE_URL,
+      ASSET_FOLDER_NAME,
       ASSET_FOLDER_NAME,
       actualImageUrlMapping,
     );
@@ -83,7 +84,13 @@ describe('packaging', () => {
     const imageUrls = await getImageUrlKeysArray();
     const actualImageUrlMapping = new Map(imageUrls.map((url) => [url, '']));
 
-    await updateAssetReferences(originalXml, PAGE_URL, ASSET_FOLDER_NAME, actualImageUrlMapping);
+    await updateReferences(
+      originalXml,
+      PAGE_URL,
+      ASSET_FOLDER_NAME,
+      ASSET_FOLDER_NAME,
+      actualImageUrlMapping,
+    );
 
     // Compare the two maps
     expect(
@@ -103,7 +110,7 @@ describe('packaging', () => {
   it('should handle XML parsing errors in updateAssetReferences', async () => {
     const invalidXml = '<invalid><xml>';
     const imageUrls = await getImageUrlKeysArray();
-    const result = await updateAssetReferences(
+    const result = await updateReferences(
       invalidXml,
       PAGE_URL,
       ASSET_FOLDER_NAME,


### PR DESCRIPTION
## Description

We should rewrite urls for content that we migrate.

## Motivation and Context

For example, a card view details links to a product page (`/products/mac-daddy`) - the jcr adjusted url should be `/content/xwalk/products/mac-daddy`, however we're currently not updating these urls, which will lead to broken links.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
