### PR TITLE
fix: update image regex to handle escaped alt text

### DIFF
--- a/src/package/asset-mapping.js
+++ b/src/package/asset-mapping.js
@@ -13,7 +13,8 @@
 // Regex for inline images & reference-style images
 // 1. inline images: ![Alt text](url "title")
 // 2. reference-style images: ![Alt text][ReferenceLabel]
-const imageRegex = /!\[([^\]]*)]\(([^) "]+)(?: *"([^"]*)")?\)|!\[([^\]]*)]\[([^\]]+)]/g;
+// Updated to handle escaped brackets in alt text using (?:\\.|[^\]])* pattern
+const imageRegex = /!\[((?:\\.|[^\]])*)\]\(([^) "]+)(?: *"([^"]*)")?\)|!\[((?:\\.|[^\]])*)\]\[([^\]]+)\]/g;
 
 // Regex for reference definitions
 const referenceRegex = /\[([^\]]+)]:\s*(\S+)/g;

--- a/test/fixtures/wknd-trendsetters/wknd-trendsetters.md
+++ b/test/fixtures/wknd-trendsetters/wknd-trendsetters.md
@@ -1,0 +1,221 @@
+---
+
+# Trendsetters, game changers, night owls
+
+From courtside cool to beachy vibes, discover the freshest looks and real stories. Get inspired by bold styles for every adventure—day or night.
+
+[See more](http://localhost:3001/fashion-insights)[Lookbook](http://localhost:3001/fashion-trends-of-the-season)
+
++-------------------------------------------------------+
+| Cards (cards29)                                       |
++=====+===========================================+=====+
+|     | ![image of hip-hop dance][image0]         |     |
++-----+-------------------------------------------+-----+
+|     | ![image of music fans at concert][image1] |     |
++-----+-------------------------------------------+-----+
+
++---------------------+
+| Section Metadata    |
++=========+===========+
+| style   | section-1 |
++---------+-----------+
+
+---
+
+## Trends made for your lifestyle
+
++----------------------------------------------------------+
+| Cards (cards19)                                          |
++=====+=============+======================================+
+|     | ![][image2] | Fresh drops for every mood—tennis    |
+|     |             | whites, beach brights, party fits.   |
+|     |             | Your next look starts here.          |
++-----+-------------+--------------------------------------+
+|     | ![][image3] | Game on! Sporty vibes meet street    |
+|     |             | style. Sneakers, sets, and all the   |
+|     |             | cool you need.                       |
++-----+-------------+--------------------------------------+
+|     | ![][image4] | Chill never looked this good. Easy   |
+|     |             | layers, bold extras—fun, effortless, |
+|     |             | always you.                          |
++-----+-------------+--------------------------------------+
+|     | ![][image5] | Ready to shine? Statement looks and  |
+|     |             | playful details for nights you’ll    |
+|     |             | never forget.                        |
++-----+-------------+--------------------------------------+
+|     | ![][image6] | Remix your style. Layer, clash,      |
+|     |             | repeat—make every outfit your own.   |
++-----+-------------+--------------------------------------+
+|     | ![][image7] | Hot new labels. Discover the brands  |
+|     |             | everyone’s buzzing about—before they |
+|     |             | go big.                              |
++-----+-------------+--------------------------------------+
+|     | ![][image8] | Real people, real style. See how     |
+|     |             | trendsetters own the scene, one      |
+|     |             | outfit at a time.                    |
++-----+-------------+--------------------------------------+
+|     | ![][image9] | Season’s essentials. Stay ahead with |
+|     |             | our top picks—what’s trending right  |
+|     |             | now.                                 |
++-----+-------------+--------------------------------------+
+
+[Browse](http://localhost:3001/fashion-insights)[Join](http://localhost:3001/fashion-trends-of-the-season)
+
+---
+
+Hot right now
+
+## Style that never sleeps
+
+Get inspired by real looks, real stories, and the freshest trends in youth fashion. See how today’s style stars own every moment.
+
+[Browse](http://localhost:3001/fashion-insights)
+
++--------------------------------------------------------------------------------------------------------------------------------------------------+
+| Cards (cards33)                                                                                                                                  |
++=====+===================================================================+========================================================================+
+|     | ![image of students during welcome week at a university][image10] | Chill                                                                  |
+|     |                                                                   |                                                                        |
+|     |                                                                   | 3 min read                                                             |
+|     |                                                                   |                                                                        |
+|     |                                                                   | ### Courtside cool, city strolls                                       |
+|     |                                                                   |                                                                        |
+|     |                                                                   | Alex mixes tennis classics with street flair—serving up a look that’s  |
+|     |                                                                   | game, set, match for any scene.                                        |
+|     |                                                                   |                                                                        |
+|     |                                                                   | [Read](http://localhost:3001/fashion-insights)                         |
++-----+-------------------------------------------------------------------+------------------------------------------------------------------------+
+|     | ![\[headshot\] image of customer (for a distillery)][image11]     | Sunny                                                                  |
+|     |                                                                   |                                                                        |
+|     |                                                                   | 4 min read                                                             |
+|     |                                                                   |                                                                        |
+|     |                                                                   | ### Wave-ready, wow-worthy                                             |
+|     |                                                                   |                                                                        |
+|     |                                                                   | Taylor keeps it breezy in bold colors and shades—proof that beach days |
+|     |                                                                   | are made for standout style.                                           |
+|     |                                                                   |                                                                        |
+|     |                                                                   | [Read](http://localhost:3001/fashion-trends-of-the-season)             |
++-----+-------------------------------------------------------------------+------------------------------------------------------------------------+
+|     | ![image of past food truck event][image12]                        | Night                                                                  |
+|     |                                                                   |                                                                        |
+|     |                                                                   | 2 min read                                                             |
+|     |                                                                   |                                                                        |
+|     |                                                                   | ### Glow up after hours                                                |
+|     |                                                                   |                                                                        |
+|     |                                                                   | Jordan turns up the party in neon layers and kicks—because the best    |
+|     |                                                                   | nights start with a killer fit.                                        |
+|     |                                                                   |                                                                        |
+|     |                                                                   | [Read](http://localhost:3001/fashion-trends-young-adults-casual-sport) |
++-----+-------------------------------------------------------------------+------------------------------------------------------------------------+
+|     | ![image of community engagement (for a food truck)][image13]      | Active                                                                 |
+|     |                                                                   |                                                                        |
+|     |                                                                   | 5 min read                                                             |
+|     |                                                                   |                                                                        |
+|     |                                                                   | ### Play hard, dress harder                                            |
+|     |                                                                   |                                                                        |
+|     |                                                                   | Morgan fuses sporty edge with fresh brands—making every match a style  |
+|     |                                                                   | moment to remember.                                                    |
+|     |                                                                   |                                                                        |
+|     |                                                                   | [Read](http://localhost:3001/fashion-insights)                         |
++-----+-------------------------------------------------------------------+------------------------------------------------------------------------+
+
++---------------------+
+| Section Metadata    |
++=========+===========+
+| style   | section-1 |
++---------+-----------+
+
+---
+
++-----------------------------------------------------------------------------------------+
+| Tabs                                                                                    |
++===========+============================+=============================================+==+
+| Trends    | ### Fresh fits, bold moves | ![image of volunteerism in nature][image14] |  |
++-----------+----------------------------+---------------------------------------------+--+
+| Sporty    | ### Game on, style up      | ![image of community gaming event][image15] |  |
++-----------+----------------------------+---------------------------------------------+--+
+| Nightlife | ### Party looks, all night | ![image of music fans at concert][image1]   |  |
++-----------+----------------------------+---------------------------------------------+--+
+
++---------------------+
+| Section Metadata    |
++=========+===========+
+| style   | section-2 |
++---------+-----------+
+
+---
+
+## Style Qs, real quick answers
+
+Fresh tips for your everyday look.
+
++---------------------------------------------------------------------------------------------+
+| Accordion                                                                                   |
++==================================+==========================================================+
+| Sneakers for night—yes or no?    | Rock bold kicks with a sleek dress or sharp pants. Add   |
+|                                  | standout accessories and you’re set for any party.       |
++----------------------------------+----------------------------------------------------------+
+| What’s hot for beach days?       | Go bright, breezy, and bold. Sporty suits, bucket hats,  |
+|                                  | and oversized sunnies bring the fun.                     |
++----------------------------------+----------------------------------------------------------+
+| Mixing sporty with casual—can I? | Totally! Try a tennis skirt with a graphic tee or toss a |
+|                                  | hoodie over swimwear for instant cool.                   |
++----------------------------------+----------------------------------------------------------+
+| How do basics get a glow-up?     | Layer textures, add color pops, or stack on chunky       |
+|                                  | jewelry. Even a cap can flip your vibe.                  |
++----------------------------------+----------------------------------------------------------+
+
++---------------------+
+| Section Metadata    |
++=========+===========+
+| style   | section-1 |
++---------+-----------+
+
+---
+
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Columns (columns3)                                                                                                                                                        |
++==========================================================+================================================================================================================+
+| ## Join the style revolution                             | [Sign up](http://localhost:3001/fashion-insights)[Connect](http://localhost:3001/fashion-trends-of-the-season) |
+|                                                          |                                                                                                                |
+| Get trend alerts, style inspo, and exclusive tips. Fresh |                                                                                                                |
+| looks, fun vibes—straight to your inbox. Don’t miss out! |                                                                                                                |
++----------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+
++----------------------+
+| Metadata             |
++=======+==============+
+| Title | Fashion Blog |
++-------+--------------+
+
+[image0]: https://cdn.prod.website-files.com/image-generation-assets/793c17eb-ae3c-458b-b8fa-a189b0052bc6.avif
+
+[image1]: https://cdn.prod.website-files.com/image-generation-assets/f55b6d62-bc1d-4700-8258-318e659fa50c.avif
+
+[image2]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTEyLjUgMTguMjVDMTYuMjI3OSAxOC4yNSAxOS4yNSAxNS4yMjc5IDE5LjI1IDExLjVDMTkuMjUgNy43NzIwOCAxNi4yMjc5IDQuNzUgMTIuNSA0Ljc1QzguNzcyMDggNC43NSA1Ljc1IDcuNzcyMDggNS43NSAxMS41QzUuNzUgMTIuNjAwNyA2LjAxMzQ1IDEzLjYzOTggNi40ODA3MiAxNC41NTc4TDUgMTlMOS43MTgxOSAxNy42NTE5QzEwLjU2NjQgMTguMDM2MSAxMS41MDgyIDE4LjI1IDEyLjUgMTguMjVaIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48L3N2Zz4=
+
+[image3]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTUuMjUgNi43NUgxOC43NVYxNy4yNUg1LjI1VjYuNzVaIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48cGF0aCBkPSJNNS4yNSA2Ljc1TDEyIDEyTDE4Ljc1IDYuNzUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==
+
+[image4]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTE5LjI1IDEyQzE5LjI1IDE2LjAwNDEgMTYuMDA0MSAxOS4yNSAxMiAxOS4yNUM3Ljk5NTk0IDE5LjI1IDQuNzUgMTYuMDA0MSA0Ljc1IDEyQzQuNzUgNy45OTU5NCA3Ljk5NTk0IDQuNzUgMTIgNC43NUMxNi4wMDQxIDQuNzUgMTkuMjUgNy45OTU5NCAxOS4yNSAxMloiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxwYXRoIGQ9Ik05IDEyTDExIDE0TDE1LjUgOS41IiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48L3N2Zz4=
+
+[image5]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTE5IDEyQzE1LjEzNCAxMiAxMiAxNS4xMzQgMTIgMTlDMTIgMTUuMTM0IDguODY1OTkgMTIgNSAxMkM4Ljg2NTk5IDEyIDEyIDguODY1OTkgMTIgNUMxMiA4Ljg2NTk5IDE1LjEzNCAxMiAxOSAxMloiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjxwYXRoIGQ9Ik04IDE2TDUuNSAxOC41IiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48cGF0aCBkPSJNOCA4TDUuNSA1LjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxwYXRoIGQ9Ik0xNiAxNkwxOC41IDE4LjUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxwYXRoIGQ9Ik0xNiA4TDE4LjUgNS41IiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48L3N2Zz4=
+
+[image6]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik05LjUgOUM5LjUgNy42MTkyOSAxMC42MTkzIDYuNSAxMiA2LjVDMTMuMzgwNyA2LjUgMTQuNSA3LjYxOTI5IDE0LjUgOUMxNC41IDEwLjM4MDcgMTMuMzgwNyAxMS41IDEyIDExLjVDMTAuNjE5MyAxMS41IDkuNSAxMC4zODA3IDkuNSA5Wk0xMiA1QzkuNzkwODYgNSA4IDYuNzkwODYgOCA5QzggMTEuMjA5MSA5Ljc5MDg2IDEzIDEyIDEzQzE0LjIwOTEgMTMgMTYgMTEuMjA5MSAxNiA5QzE2IDYuNzkwODYgMTQuMjA5MSA1IDEyIDVaTTguNzUgMTMuNUM2LjY3ODkzIDEzLjUgNSAxNS4xNzg5IDUgMTcuMjVWMTlINi41VjE3LjI1QzYuNSAxNi4wMDc0IDcuNTA3MzYgMTUgOC43NSAxNUgxNS4yNUMxNi40OTI2IDE1IDE3LjUgMTYuMDA3NCAxNy41IDE3LjI1VjE5SDE5VjE3LjI1QzE5IDE1LjE3ODkgMTcuMzIxMSAxMy41IDE1LjI1IDEzLjVIOC43NVoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg==
+
+[image7]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTYuNzUgMTguMjVWNC43NUgxMy41TDE3LjI1IDguNVYxOC4yNUg2Ljc1WiIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PC9zdmc+
+
+[image8]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTUuNzUgNS43NUgxOC4yNVYxOC4yNUg1Ljc1VjUuNzVaIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48cGF0aCBkPSJNOC43NSAzLjVWOCIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMS41Ii8+PHBhdGggZD0iTTE1LjI1IDMuNVY4IiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48cGF0aCBkPSJNMTguMjUgMTAuMjVINS43NSIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMS41Ii8+PC9zdmc+
+
+[image9]: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTE2LjM5MTggMTQuODUyN0MyMC4yNDg5IDEwLjk5NTYgMTcuMjc2OSA0LjI1IDEyIDQuMjVDNi43MjI5OSA0LjI1IDMuNzUxMDIgMTAuOTk1NiA3LjYwODE3IDE0Ljg1MjdMMTIgMTkuMjVMMTYuMzkxOCAxNC44NTI3WiIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMC4yNSIgcj0iMiIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMS41Ii8+PC9zdmc+
+
+[image10]: https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c53e53dcd1effd2b6_7101dd4d-174a-4d00-82a1-383912b95bdb.avif
+
+[image11]: https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c90d15f06db8c3063_05222b1a-c1f8-4466-a89e-8372f97aecc0.avif
+
+[image12]: https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6cd421d169780374bf_9ad18339-65d0-40a9-9bff-7b374acace0a.avif
+
+[image13]: https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c58786282145eff60_deca1497-b229-4572-bcdf-56566120eec4.avif
+
+[image14]: https://cdn.prod.website-files.com/image-generation-assets/5db1565e-357f-43eb-93a8-3692f45b38d5.avif
+
+[image15]: https://cdn.prod.website-files.com/image-generation-assets/e198cd7a-a7bd-4756-ab20-d81853a5b03f.avif

--- a/test/package/asset-mapping.test.js
+++ b/test/package/asset-mapping.test.js
@@ -156,4 +156,33 @@ Download [Regular PDF](/content/dam/documents/guide.pdf)
       'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A8A',
     ]);
   });
+
+  it('should find all assets in wknd-trendsetters.md fixture', async () => {
+    const markdownContent = await loadFile('../fixtures/wknd-trendsetters/wknd-trendsetters.md');
+    const assetUrls = getAssetUrlsFromMarkdown(markdownContent);
+
+    // Should find 9 asset URLs (including duplicates from multiple references)
+    expect(assetUrls).to.have.lengthOf(9);
+
+    // Should include the CDN image URLs that are actually found
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/image-generation-assets/793c17eb-ae3c-458b-b8fa-a189b0052bc6.avif'); // image0
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/image-generation-assets/f55b6d62-bc1d-4700-8258-318e659fa50c.avif'); // image1
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c53e53dcd1effd2b6_7101dd4d-174a-4d00-82a1-383912b95bdb.avif'); // image10
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c90d15f06db8c3063_05222b1a-c1f8-4466-a89e-8372f97aecc0.avif'); // image11
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6cd421d169780374bf_9ad18339-65d0-40a9-9bff-7b374acace0a.avif'); // image12
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/685659f2651d1abee4832887/68565a6c58786282145eff60_deca1497-b229-4572-bcdf-56566120eec4.avif'); // image13
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/image-generation-assets/5db1565e-357f-43eb-93a8-3692f45b38d5.avif'); // image14
+    expect(assetUrls).to.include('https://cdn.prod.website-files.com/image-generation-assets/e198cd7a-a7bd-4756-ab20-d81853a5b03f.avif'); // image15
+
+    // Should NOT include any data URLs (SVG base64 encoded images for image2-image9)
+    expect(assetUrls).to.not.include.members([
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTEyLjUgMTguMjVDMTYuMjI3OSAxOC4yNSAxOS4yNSA5LjIyNzkgMTkuMjUgMTEuNUMxOS4yNSA3Ljc3MjA4IDE2LjIyNzkgNC43NSAxMi41IDQuNzVDOC43NzIwOCA0Ljc1IDUuNzUgNy43NzIwOCA1Ljc1IDExLjVDNS43NSAxMi42MDA3IDYuMDEzNDUgMTMuNjM5OCA2LjQ4MDcyIDE0LjU1NzhMNSAxOUw5LjcxODE5IDE3LjY1MTlDMTAuNTY2NCAxOC4wMzYxIDExLjUwODIgMTguMjUgMTIuNSAxOC4yNVoiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==',
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTUuMjUgNi43NUgxOC43NVYxNy4yNUg1LjI1VjYuNzVaIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48cGF0aCBkPSJNNS4yNSA2Ljc1TDEyIDEyTDE4Ljc1IDYuNzUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==',
+    ]);
+
+    // Verify that all found URLs are valid (not data URLs)
+    assetUrls.forEach((url) => {
+      expect(url).to.not.match(/^data:/);
+    });
+  });
 });


### PR DESCRIPTION
The parser was having issue finding image in the markdown that had escaped alt text

`
![\[headshot\] image of customer (for a distillery)][image11]
`
