### PR TITLE
fix: Preserve asset name's original case

### DIFF
--- a/src/package/packaging.utils.js
+++ b/src/package/packaging.utils.js
@@ -196,9 +196,9 @@ export const getJcrPagePath = (pagePath, sitePath) => {
 
 /**
  * Get the JCR path for an asset.
- * NOTE: We use lower case for the asset folder names, since in AEM DAM
- * paths are case-sensitive; AEM automatically generates a JCR node name
- * that follows a lowercase, so reference paths should also use lower case.
+ * NOTE: We use lower case for the asset folder names, AEM automatically
+ * generates a JCR node name that follows a lowercase. Asset names preserve
+ * their original case.
  * @param {URL} assetUrl - The URL of the asset
  * @param {string} assetFolderName - The name of the asset folder(s) in AEM
  * @returns {string} the JCR path for the asset.
@@ -239,7 +239,18 @@ export const getJcrAssetPath = (assetUrl, assetFolderName) => {
     assetPath = assetPath.replace('/media_', '/media1_');
     jcrAssetPath = `/content/dam/${assetFolderName}${assetPath}${extension}`;
   }
-  return getSanitizedJcrPath(jcrAssetPath).toLowerCase();
+
+  // Apply sanitization first
+  const sanitizedPath = getSanitizedJcrPath(jcrAssetPath);
+
+  // Split the path to separate folders from filename
+  const pathParts = sanitizedPath.split('/');
+  const filename = pathParts.pop(); // Remove and store filename
+
+  // Make folder paths lowercase but preserve filename case
+  const lowercaseFolderPath = pathParts.join('/').toLowerCase();
+
+  return `${lowercaseFolderPath}/${filename}`;
 };
 
 /**

--- a/test/package/packaging-utils.test.js
+++ b/test/package/packaging-utils.test.js
@@ -57,14 +57,15 @@ describe('packaging-utils', () => {
   });
 
   // write a test to cover getJcrAssetPath:
-  // 1. test lowercased asset referernces
+  // 1. test lowercased folder paths with preserved asset filename case
   // 2. should not add an extra .jpg to the URL
   it('test the getJcrAssetPath', () => {
     let assetFolderName = 'DOE-Sample-Site-1';
 
-    // ensure generated path is in lower case, and has no double extension
-    let assetUrl = new URL('https://xyz/content/dam/doe/sws/image/IMG-20241017-WA0000.jpg.thumb.1280.1280.jpg');
-    let expectedJcrPath = '/content/dam/doe-sample-site-1/doe/sws/image/img-20241017-wa0000.jpg.thumb.1280.1280.jpg';
+    // ensure generated folder path is in lower case, but filename preserves case,
+    // and has no double extension
+    let assetUrl = new URL('https://xyz/content/dam/doe/sws/Image/IMG-20241017-WA0000.jpg.thumb.1280.1280.jpg');
+    let expectedJcrPath = '/content/dam/doe-sample-site-1/doe/sws/image/IMG-20241017-WA0000.jpg.thumb.1280.1280.jpg';
     let actualJcrPath = getJcrAssetPath(assetUrl, assetFolderName);
     expect(actualJcrPath).to.equal(expectedJcrPath);
 
@@ -75,8 +76,8 @@ describe('packaging-utils', () => {
     expect(actualJcrPath).to.equal(expectedJcrPath);
 
     // should generate a path if resource url has extension
-    assetUrl = new URL('https://example.com/blob/shdckh234y4');
-    expectedJcrPath = '/content/dam/doe-sample-site-1/blob/shdckh234y4';
+    assetUrl = new URL('https://example.com/blob/SHdckh234Y4');
+    expectedJcrPath = '/content/dam/doe-sample-site-1/blob/SHdckh234Y4';
     actualJcrPath = getJcrAssetPath(assetUrl, assetFolderName);
     expect(actualJcrPath).to.equal(expectedJcrPath);
 


### PR DESCRIPTION
Issue: https://github.com/adobe/helix-importer-jcr-packaging/issues/24